### PR TITLE
fix:handle subaccounts with spaces in name

### DIFF
--- a/scripts/btp_rc_assignment_tf_export.sh
+++ b/scripts/btp_rc_assignment_tf_export.sh
@@ -7,18 +7,19 @@
 VERSION="Version: 1.0"
 
 BASEDIR=$(dirname $0)
-if ! command -v _jq &> /dev/null; then
+if ! command -v _jq &>/dev/null; then
     source $BASEDIR/utils.sh
 fi
 
 # Check if the btp-cli is installed and configured
 _check_btp_cli
 
-_generate_tf_code_for_role_collection_assignment_subaccount(){
+_generate_tf_code_for_role_collection_assignment_subaccount() {
     # Generate the terraform code for the subaccount with the given GUID
     sa_name=$(btp --format json get accounts/subaccounts $1 | jq -r '.displayName')
+    sa_name_internal=$(echo $sa_name | tr '[ ]' '[\-]')
     echo "# ------------------------------------------------------------------------------------------------------"
-    echo "# Creation of role collection assigment for subaccount $sa_name"
+    echo "# Creation of role collection assigment for subaccount $sa_name_internal"
     echo "# ------------------------------------------------------------------------------------------------------"
     for user in $(btp --format json list security/user -sa $1 | jq -r '.[]'); do
         for rolecollection in $(btp --format json get security/user "$user" -sa $1 | jq -r '.roleCollections[] | @base64'); do
@@ -27,7 +28,7 @@ _generate_tf_code_for_role_collection_assignment_subaccount(){
             echo ""
             echo "# terraform code for $user and role collection $rc assignment"
             echo "resource \"btp_subaccount_role_collection_assignment\" \"$(_slugify $name)-$(_slugify "$rc")\" {"
-            echo "    subaccount_id        = btp_subaccount.$sa_name.id"
+            echo "    subaccount_id        = btp_subaccount.$sa_name_internal.id"
             echo "    role_collection_name = \"$rc\""
             echo "    user_name            = \"$user\""
             echo "}"
@@ -36,7 +37,7 @@ _generate_tf_code_for_role_collection_assignment_subaccount(){
     done
 }
 
-_generate_tf_code_for_role_collection_assignment_global_account(){
+_generate_tf_code_for_role_collection_assignment_global_account() {
     echo "# ------------------------------------------------------------------------------------------------------"
     echo "# Creation of role collection assigment for global account $1"
     echo "# ------------------------------------------------------------------------------------------------------"
@@ -60,33 +61,33 @@ if [ "$0" != "$BASH_SOURCE" ]; then
 fi
 
 case $1 in
-    -h | --help)
-        _usage
-        ;;
-    -v | --version)
-        _version
-        ;;
-    -sa | --subaccount)
-        if [ -z $2 ]; then
-            echo "The subaccount GUID is missing."
-            exit 1
-        fi
-        _generate_tf_code_for_role_collection_assignment_subaccount $2
-        ;;
-    -ga | --global-account)
-        if [ -z $2 ]; then
-            echo "The global account subdomain is missing."
-            exit 1
-        fi
-        _generate_tf_code_for_role_collection_assignment_global_account $2
-        ;;
-    -all)
-        for subaccount in $(btp --format json list accounts/subaccounts | jq -r '.value[] | @base64'); do
-            sa_id=$(_jq $subaccount '.guid')
-            _generate_tf_code_for_role_collection_assignment_subaccount $sa_id
-        done
-        ;;
-    *)
-        _usage
-        ;;
+-h | --help)
+    _usage
+    ;;
+-v | --version)
+    _version
+    ;;
+-sa | --subaccount)
+    if [ -z $2 ]; then
+        echo "The subaccount GUID is missing."
+        exit 1
+    fi
+    _generate_tf_code_for_role_collection_assignment_subaccount $2
+    ;;
+-ga | --global-account)
+    if [ -z $2 ]; then
+        echo "The global account subdomain is missing."
+        exit 1
+    fi
+    _generate_tf_code_for_role_collection_assignment_global_account $2
+    ;;
+-all)
+    for subaccount in $(btp --format json list accounts/subaccounts | jq -r '.value[] | @base64'); do
+        sa_id=$(_jq $subaccount '.guid')
+        _generate_tf_code_for_role_collection_assignment_subaccount $sa_id
+    done
+    ;;
+*)
+    _usage
+    ;;
 esac

--- a/scripts/btp_subaccount_tf_export.sh
+++ b/scripts/btp_subaccount_tf_export.sh
@@ -6,7 +6,7 @@
 VERSION="Version: 1.2"
 
 BASEDIR=$(dirname $0)
-if ! command -v _jq &> /dev/null; then
+if ! command -v _jq &>/dev/null; then
     source $BASEDIR/utils.sh
 fi
 
@@ -16,16 +16,17 @@ _check_btp_cli
 _print_subaccount_tf_code() {
     # Code to generate the terraform code for the subaccount
     sa_name=$(_jq $1 '.displayName')
+    sa_name_internal=$(echo $sa_name | tr '[ ]' '[\-]')
     sa_id=$(_jq $1 '.guid')
-    echo "data \"btp_subaccount\" \"$sa_name\" {"
+    echo "data \"btp_subaccount\" \"$sa_name_internal\" {"
     echo "  id = \"$sa_id\""
     echo "}"
     echo ""
     echo "# ------------------------------------------------------------------------------------------------------"
     echo "# Creation of subaccount"
     echo "# ------------------------------------------------------------------------------------------------------"
-    echo "# terraform code for $sa_name subaccount"
-    echo "resource \"btp_subaccount\" \"$sa_name\" {"
+    echo "# terraform code for $sa_name_internal subaccount"
+    echo "resource \"btp_subaccount\" \"$sa_name_internal\" {"
     echo "  name         = \"$sa_name\""
     echo "  subdomain    = \"$(_jq $1 '.subdomain')\""
     echo "  region       = \"$(_jq $1 '.region')\""
@@ -36,27 +37,27 @@ _print_subaccount_tf_code() {
     echo "  usage        = \"$(_jq $1 '.usedForProduction')\""
     echo "}"
     echo ""
-    echo "# Command to import the state of $sa_name subaccount"
-    echo "# terraform import btp_subaccount.$sa_name $(_jq $1 '.guid')"
+    echo "# Command to import the state of $sa_name_internal subaccount"
+    echo "# terraform import btp_subaccount.$sa_name_internal $(_jq $1 '.guid')"
     echo ""
     # Code to generate the terraform code for the entitlements for the subaccount above
     echo "# ------------------------------------------------------------------------------------------------------"
     echo "# Creation of subaccount entitlements"
     echo "# ------------------------------------------------------------------------------------------------------"
-    echo "module \"sap-btp-entitlements-$sa_name\" {"
+    echo "module \"sap-btp-entitlements-$sa_name_internal\" {"
     echo "  source       = \"aydin-ozcan/sap-btp-entitlements/btp\""
     echo "  version      = \"1.0.1\""
     echo ""
-    echo "  subaccount   = btp_subaccount.$sa_name.id"
+    echo "  subaccount   = btp_subaccount.$sa_name_internal.id"
     echo ""
     echo "  entitlements = {"
     btp --format json list accounts/entitlement --subaccount $(_jq $1 '.guid') | jq -c '.quotas | group_by(.service) | map({key: .[0].service,value: map(.plan)})' | sed 's/\[{//;s/}\]//;s/},{/\n/g;s/","value"/":"value"/g' | awk -F: '{print "    "$2" = "$4}'
     echo "  }"
     echo "}"
     echo ""
-    echo "# Command to import $sa_name entitlements"
+    echo "# Command to import $sa_name_internal entitlements"
     for ent in $(btp --format json list accounts/entitlement --subaccount $(_jq $1 '.guid') | jq -r '.quotas[] | @base64'); do
-        echo "# terraform import module.sap-btp-entitlements-$sa_name.btp_subaccount_entitlement.entitlement[\\\"$(_jq $ent '.service')-$(_jq $ent '.plan')\\\"] $(_jq $1 '.guid'),$(_jq $ent '.service'),$(_jq $ent '.plan')"
+        echo "# terraform import module.sap-btp-entitlements-$sa_name_internal.btp_subaccount_entitlement.entitlement[\\\"$(_jq $ent '.service')-$(_jq $ent '.plan')\\\"] $(_jq $1 '.guid'),$(_jq $ent '.service'),$(_jq $ent '.plan')"
         # terraform import module.sap-btp-entitlements.btp_subaccount_entitlement.entitlement[\"application-logs-lite\"] 6673841d-0558-44fb-8fab-fcba02852479,application-logs,lite
     done
     echo ""
@@ -80,32 +81,31 @@ if [ "$0" != "$BASH_SOURCE" ]; then
 fi
 
 case $1 in
-    -h | --help)
-        _usage
-        ;;
-    -v | --version)
-        _version
-        ;;
-    -sa | --subaccount)
-        if [ -z $2 ]; then
-            echo "The subaccount GUID is missing."
-            exit 1
-        fi
-        _generate_tf_code_for_subaccount $2
-        ;;
-    -ga | --global-account)
-        if [ -z $2 ]; then
-            echo "The global account subdomain is missing."
-            exit 1
-        fi
-        echo "Not implemented yet."
-        exit 0
-        ;;
-    -all)
-        _generate_tf_code_for_all_subaccounts
-        ;;
-    *)
-        _usage
-        ;;
+-h | --help)
+    _usage
+    ;;
+-v | --version)
+    _version
+    ;;
+-sa | --subaccount)
+    if [ -z $2 ]; then
+        echo "The subaccount GUID is missing."
+        exit 1
+    fi
+    _generate_tf_code_for_subaccount $2
+    ;;
+-ga | --global-account)
+    if [ -z $2 ]; then
+        echo "The global account subdomain is missing."
+        exit 1
+    fi
+    echo "Not implemented yet."
+    exit 0
+    ;;
+-all)
+    _generate_tf_code_for_all_subaccounts
+    ;;
+*)
+    _usage
+    ;;
 esac
-


### PR DESCRIPTION
Hi,
since the subacount name can acept blank spaces in its name, in that case the generation of TF resources names is incorrect. I substituted eventual " " with "-" character.

For doing so I create a new variable sa_name_internal, leaving as is the sa_name, that should refer to the "display name" of the subaccount